### PR TITLE
Support request options in APIs [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# IDEA project dir
+.idea
+

--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func Example() {
 	call, _ := client.Calls.MakeCall("+14105551234", "+14105556789", callURL)
 	fmt.Println(call.Sid, call.FriendlyPrice())
 
-	_, err := client.IncomingNumbers.BuyNumber("+1badnumber")
+	_, err := client.IncomingNumbers.BuyNumber(context.TODO(),"+1badnumber")
 	// Twilio API errors are converted to rest.Error types
 	if err != nil {
 		restErr, ok := err.(*rest.Error)

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2,7 +2,6 @@ package twilio
 
 import (
 	"context"
-	"net/url"
 
 	types "github.com/kevinburke/go-types"
 )
@@ -65,21 +64,21 @@ type IncomingPhoneNumberPage struct {
 // Create a phone number (buy a number) with the given values.
 //
 // https://www.twilio.com/docs/api/rest/incoming-phone-numbers#toll-free-incomingphonenumber-factory-resource
-func (n *NumberPurchasingService) Create(ctx context.Context, data url.Values) (*IncomingPhoneNumber, error) {
+func (n *NumberPurchasingService) Create(ctx context.Context, opts ...RequestOption) (*IncomingPhoneNumber, error) {
 	number := new(IncomingPhoneNumber)
 	pathPart := numbersPathPart
 	if n.pathPart != "" {
 		pathPart += "/" + n.pathPart
 	}
-	err := n.client.CreateResource(ctx, pathPart, data, number)
+	err := n.client.CreateResource(ctx, pathPart, getValues(opts...), number)
 	return number, err
 }
 
 // BuyNumber attempts to buy the provided phoneNumber and returns it if
 // successful.
-func (ipn *IncomingNumberService) BuyNumber(phoneNumber string) (*IncomingPhoneNumber, error) {
-	data := url.Values{"PhoneNumber": []string{phoneNumber}}
-	return ipn.NumberPurchasingService.Create(context.Background(), data)
+func (ipn *IncomingNumberService) BuyNumber(ctx context.Context, phoneNumber string, opts ...RequestOption) (*IncomingPhoneNumber, error) {
+	opts = append(opts, WithPhoneNumber(phoneNumber))
+	return ipn.NumberPurchasingService.Create(ctx, opts...)
 }
 
 // Get retrieves a single IncomingPhoneNumber.
@@ -95,8 +94,8 @@ func (ipn *IncomingNumberService) Release(ctx context.Context, sid string) error
 }
 
 // GetPage retrieves an IncomingPhoneNumberPage, filtered by the given data.
-func (ins *IncomingNumberService) GetPage(ctx context.Context, data url.Values) (*IncomingPhoneNumberPage, error) {
-	iter := ins.GetPageIterator(data)
+func (ins *IncomingNumberService) GetPage(ctx context.Context, opts ...RequestOption) (*IncomingPhoneNumberPage, error) {
+	iter := ins.GetPageIterator(opts...)
 	return iter.Next(ctx)
 }
 
@@ -105,8 +104,8 @@ type IncomingPhoneNumberPageIterator struct {
 }
 
 // GetPageIterator returns an iterator which can be used to retrieve pages.
-func (c *IncomingNumberService) GetPageIterator(data url.Values) *IncomingPhoneNumberPageIterator {
-	iter := NewPageIterator(c.client, data, numbersPathPart)
+func (c *IncomingNumberService) GetPageIterator(opts ...RequestOption) *IncomingPhoneNumberPageIterator {
+	iter := NewPageIterator(c.client, getValues(opts...), numbersPathPart)
 	return &IncomingPhoneNumberPageIterator{
 		p: iter,
 	}

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -2,7 +2,6 @@ package twilio
 
 import (
 	"context"
-	"net/url"
 	"testing"
 	"time"
 
@@ -14,10 +13,9 @@ func TestGetNumberPage(t *testing.T) {
 		t.Skip("skipping HTTP request in short mode")
 	}
 	t.Parallel()
-	data := url.Values{"PageSize": []string{"1000"}}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	numbers, err := envClient.IncomingNumbers.GetPage(ctx, data)
+	numbers, err := envClient.IncomingNumbers.GetPage(ctx, WithPageSize(1000))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +29,7 @@ func TestBuyNumber(t *testing.T) {
 		t.Skip("skipping HTTP request in short mode")
 	}
 	t.Parallel()
-	_, err := envClient.IncomingNumbers.BuyNumber("+1foobar")
+	_, err := envClient.IncomingNumbers.BuyNumber(context.Background(), "+1foobar")
 	if err == nil {
 		t.Fatal("expected to get an error, got nil")
 	}

--- a/request_option.go
+++ b/request_option.go
@@ -1,0 +1,87 @@
+package twilio
+
+import (
+	"net/url"
+	"strconv"
+)
+
+type RequestOption func(values url.Values)
+
+func WithFriendlyName(name string) RequestOption {
+	return WithOption("FriendlyName", name)
+}
+
+func WithAreaCode(areaCode string) RequestOption {
+	return WithOption("AreaCode", areaCode)
+}
+
+func WithPageSize(size int) RequestOption {
+	return WithOption("PageSize", strconv.Itoa(size))
+}
+
+func WithPhoneNumber(phoneNumber string) RequestOption {
+	return WithOption("PhoneNumber", phoneNumber)
+}
+
+func WithSmsEnabled(enabled bool) RequestOption {
+	return WithOption("SmsEnabled", strconv.FormatBool(enabled))
+}
+
+func WithMmsEnabled(enabled bool) RequestOption {
+	return WithOption("MmsEnabled", strconv.FormatBool(enabled))
+}
+
+func WithVoiceEnabled(enabled bool) RequestOption {
+	return WithOption("VoiceEnabled", strconv.FormatBool(enabled))
+}
+
+func WithFaxEnabled(enabled bool) RequestOption {
+	return WithOption("FaxEnabled", strconv.FormatBool(enabled))
+}
+
+func WithStatus(status string) RequestOption {
+	return WithOption("Status", status)
+}
+
+func WithSid(sid string) RequestOption {
+	return WithOption("Sid", sid)
+}
+
+func WithAccountSid(accountSid string) RequestOption {
+	return WithOption("AccountSid", accountSid)
+}
+
+func WithTrunkSid(trunkSid string) RequestOption {
+	return WithOption("TrunkSid", trunkSid)
+}
+
+func WithStreet(street string) RequestOption {
+	return WithOption("Street", street)
+}
+
+func WithCity(city string) RequestOption {
+	return WithOption("City", city)
+}
+
+func WithRegion(region string) RequestOption {
+	return WithOption("Region", region)
+}
+
+func WithPostalCode(postalCode string) RequestOption {
+	return WithOption("PostalCode", postalCode)
+}
+
+func WithOption(key string, val string) RequestOption {
+	return func(values url.Values) {
+		values.Add(key, val)
+	}
+}
+
+func getValues(opts ...RequestOption) url.Values {
+	v := url.Values{}
+	for _, f := range opts {
+		f(v)
+	}
+
+	return v
+}

--- a/request_option_test.go
+++ b/request_option_test.go
@@ -1,0 +1,64 @@
+package twilio
+
+import "testing"
+
+func TestRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	vals := getValues(
+		WithFriendlyName("test"),
+		WithAreaCode("562"),
+		WithSmsEnabled(true),
+		WithMmsEnabled(false),
+		WithVoiceEnabled(true),
+		WithFaxEnabled(false),
+		WithStatus("active"),
+		WithSid("123"),
+		WithAccountSid("321"),
+		WithTrunkSid("213"),
+		WithStreet("S"),
+		WithCity("C"),
+		WithRegion("R"),
+		WithPostalCode("02123"),
+		WithOption("Custom", "111"),
+	)
+
+	expected := map[string][]string{
+		"FriendlyName": {"test"},
+		"AreaCode":     {"562"},
+		"SmsEnabled":   {"true"},
+		"MmsEnabled":   {"false"},
+		"VoiceEnabled": {"true"},
+		"FaxEnabled":   {"false"},
+		"Status":       {"active"},
+		"Sid":          {"123"},
+		"AccountSid":   {"321"},
+		"TrunkSid":     {"213"},
+		"Street":       {"S"},
+		"City":         {"C"},
+		"Region":       {"R"},
+		"PostalCode":   {"02123"},
+		"Custom":       {"111"},
+	}
+
+	if len(expected) != len(vals) {
+		t.Fatal("invalid map size")
+	}
+
+	for k, expected := range expected {
+		actual, ok := vals[k]
+		if !ok {
+			t.Fatalf("expected key not found %s", k)
+		}
+
+		if len(expected) != len(actual) {
+			t.Fatalf("unexpected len for key: %s", k)
+		}
+
+		for i, x := range expected {
+			if x != actual[i] {
+				t.Errorf("not equal values at %d for key '%s' ('%v' != '%v')", i, k, x, actual[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is draft proposal

This PR uses functional options pattern ([1](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) and [2](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)) and allows to use `twilio-go` library in more convenient and strongly-typed way.

Before:
```
p := url.Values{}
p.Set("FriendlyName", userId)
api.Accounts.Create(c.ctx, p)
```

After:
```
api.Accounts.Create(c.ctx, WithFriendlyName(userId))

api.Accounts.GetPage(c.ctx, WithPageSize(1000), WithFriendlyName("XXX"), WithStatus("active"))
or
api.Accounts.GetPage(c.ctx)
```

However it makes API backward incompatible in some places

@kevinburke what do you think?