### PR TITLE
Make Segments and NumMedia unmarshaler more flexible

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -175,6 +175,9 @@ func TestDecode(t *testing.T) {
 	if msg.FriendlyPrice() != "$0.0075" {
 		t.Errorf("wrong friendly price %v, want %v", msg.FriendlyPrice(), "$0.00750")
 	}
+	if msg.NumSegments != 1 {
+		t.Errorf("wrong num segment %d, want %d", msg.NumSegments, 1)
+	}
 }
 
 func TestStatusFriendly(t *testing.T) {

--- a/responses_test.go
+++ b/responses_test.go
@@ -291,7 +291,7 @@ var getMessageResponse = []byte(`
     "from": "+19253920364",
     "messaging_service_sid": null,
     "num_media": "0",
-    "num_segments": "1",
+    "num_segments": 1,
     "price": "-0.00750",
     "price_unit": "USD",
     "sid": "SM26b3b00f8def53be77c5697183bfe95e",

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package twilio
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,11 +71,7 @@ type Segments uintStr
 type NumMedia uintStr
 
 func (seg *uintStr) UnmarshalJSON(b []byte) error {
-	s := new(string)
-	if err := json.Unmarshal(b, s); err != nil {
-		return err
-	}
-	u, err := strconv.ParseUint(*s, 10, 64)
+	u, err := strconv.ParseUint(string(bytes.Trim(b, `"`)), 10, 64)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Twilio returns `num_segments` and `num_media` fields as string-quoted, but other providers (namely SignalWire) returns these [two fields as ints](https://docs.signalwire.com/topics/laml-api/#api-reference-messages). 

This PR changes `uintStr.UnmarshalJSON()` to be able to parse both:
- string-quoted values
- integer values