### PR TITLE
added Programmable Chat grant type

### DIFF
--- a/token/access_token_grant.go
+++ b/token/access_token_grant.go
@@ -17,6 +17,7 @@ const (
 	keyVoiceParams     = "params"
 	// https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens
 	keyRoomSid = "room"
+	chatGrant  = "chat"
 )
 
 // Grant is a Twilio SID resource that can be added to an AccessToken for extra
@@ -147,4 +148,26 @@ func (gr *VideoGrant) ToPayload() map[string]interface{} {
 
 func (gr *VideoGrant) Key() string {
 	return videoGrant
+}
+
+// ChatGrant is for Twilio Programmable Chat
+type ChatGrant struct {
+	serviceSid string
+}
+
+func NewChatGrant(sid string) *ChatGrant {
+	return &ChatGrant{serviceSid: sid}
+}
+
+func (cg *ChatGrant) ToPayload() map[string]interface{} {
+	if len(cg.serviceSid) > 0 {
+		return map[string]interface{}{
+			keyServiceSid: cg.serviceSid,
+		}
+	}
+	return make(map[string]interface{})
+}
+
+func (cg *ChatGrant) Key() string {
+	return chatGrant
 }

--- a/token/access_token_grant_test.go
+++ b/token/access_token_grant_test.go
@@ -106,3 +106,16 @@ func TestVideoGrant(t *testing.T) {
 		t.Errorf("%s expected to be %s, got %s\n", keyRoomSid, ROOM_SID, vdGrnt.ToPayload()[keyRoomSid])
 	}
 }
+
+func TestChatGrant(t *testing.T) {
+	t.Parallel()
+	chGrnt := NewChatGrant(SERVICE_SID)
+
+	if chGrnt.Key() != chatGrant {
+		t.Errorf("key expected to be %s, got %s\n", chatGrant, chGrnt.Key())
+	}
+
+	if chGrnt.ToPayload()[keyServiceSid] != SERVICE_SID {
+		t.Errorf("%s expected to be %s, got %s\n", keyServiceSid, SERVICE_SID, chGrnt.ToPayload()[keyServiceSid])
+	}
+}


### PR DESCRIPTION
Minimum change necessary in order to use the REST API for Twilio's Programmable Chat by adding the chat grant type.