### PR TITLE
twilio: add Messaging Services API

### DIFF
--- a/http.go
+++ b/http.go
@@ -54,6 +54,10 @@ const NotifyVersion = "v1"
 const LookupBaseURL = "https://lookups.twilio.com"
 const LookupVersion = "v1"
 
+// Messaging Service
+const MessagingBaseURL = "https://messaging.twilio.com"
+const MessagingVersion = "v1"
+
 // Verify service
 const VerifyBaseURL = "https://verify.twilio.com"
 const VerifyVersion = "v2"
@@ -84,6 +88,7 @@ type Client struct {
 	Video      *Client
 	TaskRouter *Client
 	Insights   *Client
+	Message    *Client
 
 	// FullPath takes a path part (e.g. "Messages") and
 	// returns the full API path, including the version (e.g.
@@ -143,6 +148,9 @@ type Client struct {
 
 	// NewInsightsClient initializes these services
 	VoiceInsights func(sid string) *VoiceInsightsService
+
+	// NewMessageClient initializes these services
+	Services *ServiceService
 }
 
 const defaultTimeout = 30*time.Second + 500*time.Millisecond
@@ -332,6 +340,14 @@ func NewLookupClient(accountSid string, authToken string, httpClient *http.Clien
 	return c
 }
 
+// NewMessageClient returns a new Client to use the messaging API
+func NewMessageClient(accountSid string, authToken string, httpClient *http.Client) *Client {
+	c := newNewClient(accountSid, authToken, MessagingBaseURL, httpClient)
+	c.APIVersion = MessagingVersion
+	c.Services = &ServiceService{client: c}
+	return c
+}
+
 // NewVerifyClient returns a new Client to use the verify API
 func NewVerifyClient(accountSid string, authToken string, httpClient *http.Client) *Client {
 	c := newNewClient(accountSid, authToken, VerifyBaseURL, httpClient)
@@ -377,6 +393,7 @@ func NewClient(accountSid string, authToken string, httpClient *http.Client) *Cl
 	c.Video = NewVideoClient(accountSid, authToken, httpClient)
 	c.TaskRouter = NewTaskRouterClient(accountSid, authToken, httpClient)
 	c.Insights = NewInsightsClient(accountSid, authToken, httpClient)
+	c.Message = NewMessageClient(accountSid, authToken, httpClient)
 
 	c.Accounts = &AccountService{client: c}
 	c.Applications = &ApplicationService{client: c}

--- a/responses_test.go
+++ b/responses_test.go
@@ -66,6 +66,7 @@ func getServer(response []byte) (*Client, *Server) {
 	client.Video.Base = s.URL
 	client.TaskRouter.Base = s.URL
 	client.Insights.Base = s.URL
+	client.Message.Base = s.URL
 	return client, s
 }
 
@@ -2899,7 +2900,7 @@ var phoneLookupResponse = []byte(`
         "caller_name": "CCSF",
         "caller_type": "BUSINESS",
         "error_code": null
-    },    
+    },
     "carrier": {
         "type": "landline",
         "error_code": null,
@@ -2907,7 +2908,7 @@ var phoneLookupResponse = []byte(`
         "mobile_country_code": null,
         "name": "Pacific Bell"
     }
-}	
+}
 `)
 
 var verifyResponse = []byte(`

--- a/services.go
+++ b/services.go
@@ -1,0 +1,187 @@
+package twilio
+
+import (
+	"context"
+	"github.com/kevinburke/go-types"
+	"net/url"
+	"strings"
+)
+
+type ServiceService struct {
+	client *Client
+}
+
+type Service struct {
+	Sid                   string           `json:"sid"`
+	AccountSid            string           `json:"account_sid"`
+	FriendlyName          string           `json:"friendly_name"`
+	DateCreated           TwilioTime       `json:"date_created"`
+	DateUpdated           TwilioTime       `json:"date_updated"`
+	InboundRequestURL     types.NullString `json:"inbound_request_url"`
+	InboundMethod         string           `json:"inbound_method"`
+	FallbackURL           string           `json:"fallback_url"`
+	FallbackMethod        string           `json:"fallback_method"`
+	StatusCallback        string           `json:"status_callback"`
+	StickySender          bool             `json:"sticky_sender"`
+	MMSConverter          bool             `json:"mms_converter"`
+	SmartEncoding         bool             `json:"smart_encoding"`
+	FallbackToLongCode    bool             `json:"fallbackToLongCode"`
+	AreaCodeGeomatch      bool             `json:"area_code_geomatch"`
+	ValidityPeriod        uint             `json:"validity_period"`
+	SynchronousValidation bool             `json:"synchronous_validation"`
+}
+
+type ServicePhoneNumber struct {
+	Sid         string      `json:"sid"`
+	PhoneNumber PhoneNumber `json:"phone_number"`
+	ServiceSid  string      `json:"service_sid"`
+	DateCreated TwilioTime  `json:"date_created"`
+	AccountSid  string      `json:"account_sid"`
+	DateUpdated TwilioTime  `json:"date_updated"`
+	CountryCode string      `json:"country_code"`
+	URL         string      `json:"url"`
+}
+
+// A ServicePage contains a Page of services.
+type ServicePage struct {
+	Page
+	Services []*Service `json:"services"`
+}
+
+// A ServicePhoneNumberPage contains a Page of service phone numbers
+type ServicePhoneNumberPage struct {
+	Page
+	PhoneNumbers []*ServicePhoneNumber `json:"phone_numbers"`
+}
+
+// Create a service with the given url.Values. For more information on valid
+// values, see https://www.twilio.com/docs/sms/services/api#create-a-service-resource
+func (s *ServiceService) Create(ctx context.Context, data url.Values) (*Service, error) {
+	msg := new(Service)
+	err := s.client.CreateResource(ctx, servicesPathPart, data, msg)
+	return msg, err
+}
+
+// Tries to update the service's properties, and returns the updated resource representation if successful.
+// https://www.twilio.com/docs/sms/services/api#update-a-service-resource
+func (s *ServiceService) Update(ctx context.Context, sid string, data url.Values) (*Service, error) {
+	service := new(Service)
+	err := s.client.UpdateResource(ctx, servicesPathPart, sid, data, service)
+	return service, err
+}
+
+// Adds the given IncomingPhoneNumber to the messaging Service
+func (s *ServiceService) CreatePhoneNumber(ctx context.Context, serviceSid string, phoneNumberSid string) (*ServicePhoneNumber, error) {
+	pn := new(ServicePhoneNumber)
+	v := url.Values{}
+	v.Set("PhoneNumberSid", phoneNumberSid)
+	path := strings.Join([]string{servicesPathPart, serviceSid, phoneNumbersPathPart}, "/")
+	err := s.client.CreateResource(ctx, path, v, pn)
+	return pn, err
+}
+
+// Gets the ServicePhoneNumber by phoneNumberSid associated with the given Service by serviceSid
+func (s *ServiceService) GetPhoneNumber(ctx context.Context, serviceSid string, phoneNumberSid string) (*ServicePhoneNumber, error) {
+	msg := new(ServicePhoneNumber)
+	path := strings.Join([]string{servicesPathPart, serviceSid, phoneNumbersPathPart}, "/")
+	err := s.client.GetResource(ctx, path, phoneNumberSid, msg)
+	return msg, err
+}
+
+// Removes the ServicePhoneNumber with the given phoneNumberSid from the Service with the given serviceSid.
+// If the PhoneNumber has already been deleted, or does not exist, DeletePhoneNumber returns nil. If another error or a
+// timeout occurs, the error is returned.
+func (s *ServiceService) DeletePhoneNumber(ctx context.Context, serviceSid string, phoneNumberSid string) error {
+	path := strings.Join([]string{servicesPathPart, serviceSid, phoneNumbersPathPart}, "/")
+	return s.client.DeleteResource(ctx, path, phoneNumberSid)
+}
+
+// ServicePageIterator lets you retrieve consecutive pages of resources.
+type ServicePageIterator interface {
+	// Next returns the next page of resources. If there are no more resources,
+	// NoMoreResults is returned.
+	Next(context.Context) (*ServicePage, error)
+}
+
+type servicePageIterator struct {
+	p *PageIterator
+}
+
+// ServicePageIterator lets you retrieve consecutive pages of resources.
+type ServicePhoneNumberPageIterator interface {
+	// Next returns the next page of resources. If there are no more resources,
+	// NoMoreResults is returned.
+	Next(context.Context) (*ServicePhoneNumberPage, error)
+}
+
+type servicePhoneNumberPageIterator struct {
+	p *PageIterator
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *servicePageIterator) Next(ctx context.Context) (*ServicePage, error) {
+	mp := new(ServicePage)
+	err := s.p.Next(ctx, mp)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(mp.NextPageURI)
+	return mp, nil
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *servicePhoneNumberPageIterator) Next(ctx context.Context) (*ServicePhoneNumberPage, error) {
+	mp := new(ServicePhoneNumberPage)
+	err := s.p.Next(ctx, mp)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(mp.NextPageURI)
+	return mp, nil
+}
+
+// GetPageIterator returns an iterator which can be used to retrieve pages.
+func (s *ServiceService) GetPageIterator(data url.Values) ServicePageIterator {
+	iter := NewPageIterator(s.client, data, servicesPathPart)
+	return &servicePageIterator{
+		p: iter,
+	}
+}
+
+// GetPageIterator returns an iterator which can be used to retrieve pages.
+func (s *ServiceService) GetPhoneNumberPageIterator(serviceSid string, data url.Values) ServicePhoneNumberPageIterator {
+	path := strings.Join([]string{servicesPathPart, serviceSid, phoneNumbersPathPart}, "/")
+	iter := NewPageIterator(s.client, data, path)
+	return &servicePhoneNumberPageIterator{
+		p: iter,
+	}
+}
+
+func (s *ServiceService) Get(ctx context.Context, sid string) (*Service, error) {
+	msg := new(Service)
+	err := s.client.GetResource(ctx, servicesPathPart, sid, msg)
+	return msg, err
+}
+
+// GetPage returns a single page of resources. To retrieve multiple pages, use
+// GetPageIterator.
+func (s *ServiceService) GetPage(ctx context.Context, data url.Values) (*ServicePage, error) {
+	iter := s.GetPageIterator(data)
+	return iter.Next(ctx)
+}
+
+// GetPhoneNumberPage returns a single page of resources. To retrieve multiple pages, use
+// GetPageIterator.
+func (s *ServiceService) GetPhoneNumberPage(ctx context.Context, serviceSid string, data url.Values) (*ServicePhoneNumberPage, error) {
+	iter := s.GetPhoneNumberPageIterator(serviceSid, data)
+	return iter.Next(ctx)
+}
+
+// Delete the Service with the given sid. If the Service has already been
+// deleted, or does not exist, Delete returns nil. If another error or a
+// timeout occurs, the error is returned.
+func (s *ServiceService) Delete(ctx context.Context, sid string) error {
+	return s.client.DeleteResource(ctx, servicesPathPart, sid)
+}

--- a/services_test.go
+++ b/services_test.go
@@ -1,0 +1,84 @@
+package twilio
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestService_Create(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	friendlyName := fmt.Sprintf("test-messaging-service-%d", rand.Int())
+	data := url.Values{"FriendlyName": []string{friendlyName}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	service, err := envClient.Message.Services.Create(ctx, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(service.Sid) == 0 {
+		t.Error("expected to create a messaging services, got back 0")
+	}
+	if service.FriendlyName != friendlyName {
+		t.Error("friendly name was not set correctly")
+	}
+}
+
+func TestService_GetPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	data := url.Values{"PageSize": []string{"1000"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	services, err := envClient.Message.Services.GetPage(ctx, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(services.Services) == 0 {
+		t.Error("expected to get a list of messaging services, got back 0")
+	}
+}
+
+func TestServiceService_PhoneNumbers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	data := url.Values{"PageSize": []string{"5"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	numbers, err := envClient.IncomingNumbers.GetPage(ctx, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(numbers.IncomingPhoneNumbers) == 0 {
+		t.Error("expected to get a list of phone numbers, got back 0")
+	}
+	services, err := envClient.Message.Services.GetPage(ctx, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(services.Services) == 0 {
+		t.Error("expected to get a messaging services, got back 0")
+	}
+
+	number := numbers.IncomingPhoneNumbers[0]
+	service := services.Services[0]
+	if _, err := envClient.Message.Services.CreatePhoneNumber(ctx, service.Sid, number.Sid); err != nil {
+		t.Error("expected to CreatePhoneNumber but got error", err)
+	}
+
+	if _, err := envClient.Message.Services.GetPhoneNumber(ctx, service.Sid, number.Sid); err != nil {
+		t.Error("expected to GetPhoneNumber after CreatePhoneNumber but got error", err)
+	}
+
+	if err := envClient.Message.Services.DeletePhoneNumber(ctx, service.Sid, number.Sid); err != nil {
+		t.Error("expected to DeletePhoneNumber after CreatePhoneNumber but got error", err)
+	}
+}


### PR DESCRIPTION
The naming of some of the properties I've added was not ideal.

I would have liked that we could have used "client.Messaging" for the new client for https://messaging.twilio.com/v1, but unfortunately the "Messaging" property is already taken by the messaging pricing service

I choose "Message" as it was the closest I could get.

I also don't love that the entity is called "ServiceService" however the URL path is https://messaging.twilio.com/v1/Services/ so I didn't think calling it MessagingServiceService was correct.

I'm happy to change any of the names of course.