### PR TITLE
Fix tags type in voice insights summary response

### DIFF
--- a/voice_insights_summary.go
+++ b/voice_insights_summary.go
@@ -30,7 +30,7 @@ type CallSummary struct {
 	SDKEdge         *SDKEdge              `json:"sdk_edge,omitempty"`
 	SIPEdge         *Edge                 `json:"sip_edge,omitempty"`
 	StartTime       TwilioTime            `json:"start_time"`
-	Tags            map[string]string     `json:"tags"`
+	Tags            []string              `json:"tags"`
 	To              CallParty             `json:"to"`
 	URL             string                `json:"url"`
 }
@@ -86,11 +86,11 @@ type SDKEdge struct {
 
 type SDKEdgeSummary struct {
 	EdgeSummary
-	MOS      MetricsSummary    `json:"mos"`
-	RTT      MetricsSummary    `json:"rtt"`
-	Tags     map[string]string `json:"tags"`
-	AudioOut MetricsSummary    `json:"audio_out"`
-	AudioIn  MetricsSummary    `json:"audio_in"`
+	MOS      MetricsSummary `json:"mos"`
+	RTT      MetricsSummary `json:"rtt"`
+	Tags     []string       `json:"tags"`
+	AudioOut MetricsSummary `json:"audio_out"`
+	AudioIn  MetricsSummary `json:"audio_in"`
 }
 
 type SDKEdgeProperties struct {


### PR DESCRIPTION
Turns out that the `tags` field in the [Voice Insights Summary](https://www.twilio.com/docs/voice/insights/api/call-summary-resource) response is actually an array of strings, and not a map.

This PR fixes that.

