### PR TITLE
Add the "read" status (WhatsApp)

### DIFF
--- a/types.go
+++ b/types.go
@@ -298,6 +298,10 @@ const StatusRinging = Status("ringing")
 
 const StatusProcessing = Status("processing")
 
+// WhatsApp statuses
+
+const StatusRead = Status("read")
+
 // Shared statuses
 
 const StatusActive = Status("active")


### PR DESCRIPTION
WhatsApp supports the "read" status, so I've added it as one of the Status constants.

See: https://www.twilio.com/docs/sms/api/message-resource#message-status-values