### PR TITLE
Implement Marshaler interface for Segments, NumMedia and TwilioDuration, fix TwilioTime's MarshalJSON receiver type

### DIFF
--- a/http.go
+++ b/http.go
@@ -528,6 +528,7 @@ func (c *Client) MakeRequest(ctx context.Context, method string, pathPart string
 		pathPart = pathPart + "?" + data.Encode()
 	}
 	req, err := c.NewRequest(method, pathPart, rb)
+	req.Close = true
 	if err != nil {
 		return err
 	}

--- a/types.go
+++ b/types.go
@@ -158,11 +158,11 @@ func (t *TwilioTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (tt *TwilioTime) MarshalJSON() ([]byte, error) {
-	if !tt.Valid {
+func (t TwilioTime) MarshalJSON() ([]byte, error) {
+	if !t.Valid {
 		return []byte("null"), nil
 	}
-	b, err := json.Marshal(tt.Time)
+	b, err := json.Marshal(t.Time)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/types.go
+++ b/types.go
@@ -238,6 +238,13 @@ func (td *TwilioDuration) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (td TwilioDuration) MarshalJSON() ([]byte, error) {
+	if td == 0 {
+		return []byte("null"), nil
+	}
+	return json.Marshal(fmt.Sprintf("%d", td/TwilioDuration(time.Second)))
+}
+
 func (td TwilioDuration) String() string {
 	return time.Duration(td).String()
 }

--- a/types.go
+++ b/types.go
@@ -96,8 +96,8 @@ func (seg *Segments) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (seg Segments) MarshalJSON() ([]byte, error) {
-	s := fmt.Sprintf("%d", seg)
-	return json.Marshal(s)
+	s := strconv.AppendUint(nil, uint64(seg), 10)
+	return json.Marshal(string(s))
 }
 
 func (n *NumMedia) UnmarshalJSON(b []byte) (err error) {
@@ -110,8 +110,8 @@ func (n *NumMedia) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (n NumMedia) MarshalJSON() ([]byte, error) {
-	s := fmt.Sprintf("%d", n)
-	return json.Marshal(s)
+	s := strconv.AppendUint(nil, uint64(n), 10)
+	return json.Marshal(string(s))
 }
 
 // TwilioTime can parse a timestamp returned in the Twilio API and turn it into
@@ -242,7 +242,8 @@ func (td TwilioDuration) MarshalJSON() ([]byte, error) {
 	if td == 0 {
 		return []byte("null"), nil
 	}
-	return json.Marshal(fmt.Sprintf("%d", td/TwilioDuration(time.Second)))
+	s := strconv.AppendInt(nil, int64(td/TwilioDuration(time.Second)), 10)
+	return json.Marshal(string(s))
 }
 
 func (td TwilioDuration) String() string {

--- a/types.go
+++ b/types.go
@@ -95,6 +95,11 @@ func (seg *Segments) UnmarshalJSON(b []byte) (err error) {
 	return
 }
 
+func (seg Segments) MarshalJSON() ([]byte, error) {
+	s := fmt.Sprintf("%d", seg)
+	return json.Marshal(s)
+}
+
 func (n *NumMedia) UnmarshalJSON(b []byte) (err error) {
 	u := new(uintStr)
 	if err = json.Unmarshal(b, u); err != nil {
@@ -102,6 +107,11 @@ func (n *NumMedia) UnmarshalJSON(b []byte) (err error) {
 	}
 	*n = NumMedia(*u)
 	return
+}
+
+func (n NumMedia) MarshalJSON() ([]byte, error) {
+	s := fmt.Sprintf("%d", n)
+	return json.Marshal(s)
 }
 
 // TwilioTime can parse a timestamp returned in the Twilio API and turn it into

--- a/types_test.go
+++ b/types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 )
@@ -164,5 +165,57 @@ func TestUnmarshalHeader(t *testing.T) {
 	}
 	if vals := h.Values["CF-RAY"]; vals[1] != "two" {
 		t.Errorf("expected second header to be 'two', got %v", vals[1])
+	}
+}
+
+var marshalUnmarshalSegmentsTests = []Segments{
+	0,
+	100,
+	math.MaxUint32,
+	Segments(^uint(0)),
+}
+
+func TestMarshalUnmarshalSegments(t *testing.T) {
+	t.Parallel()
+	for _, tt := range marshalUnmarshalSegmentsTests {
+		b, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var seg Segments
+		if err := json.Unmarshal(b, &seg); err != nil {
+			t.Fatal(err)
+		}
+
+		if tt != seg {
+			t.Fatalf("expected %d, got %d", tt, seg)
+		}
+	}
+}
+
+var marshalUnmarshalNumMediaTests = []NumMedia{
+	0,
+	100,
+	math.MaxUint32,
+	NumMedia(^uint(0)),
+}
+
+func TestMarshalUnmarshalNumMedia(t *testing.T) {
+	t.Parallel()
+	for _, tt := range marshalUnmarshalNumMediaTests {
+		b, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var numMedia NumMedia
+		if err := json.Unmarshal(b, &numMedia); err != nil {
+			t.Fatal(err)
+		}
+
+		if tt != numMedia {
+			t.Fatalf("expected %d, got %d", tt, numMedia)
+		}
 	}
 }

--- a/types_test.go
+++ b/types_test.go
@@ -146,6 +146,31 @@ func TestTwilioDuration(t *testing.T) {
 	}
 }
 
+var marshalUnmarshalTwilioDurationTests = []TwilioDuration{
+	0,
+	1 * TwilioDuration(time.Second),
+	88 * TwilioDuration(time.Second),
+}
+
+func TestMarshalUnmarshalTwilioDuration(t *testing.T) {
+	t.Parallel()
+	for _, tt := range marshalUnmarshalTwilioDurationTests {
+		b, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var td TwilioDuration
+		if err := json.Unmarshal(b, &td); err != nil {
+			t.Fatal(err)
+		}
+
+		if tt != td {
+			t.Fatalf("expected %d, got %d", tt, td)
+		}
+	}
+}
+
 var hdr = `"Transfer-Encoding=chunked&Server=cloudflare-nginx&CF-RAY=2f82bf9cb8102204-EWR&Set-Cookie=__cfduid%3Dd46f1cfd57d664c3038ae66f1c1de9e751477535661%3B+expires%3DFri%2C+27-Oct-17+02%3A34%3A21+GMT%3B+path%3D%2F%3B+domain%3D.inburke.com%3B+HttpOnly&Date=Thu%2C+27+Oct+2016+02%3A34%3A21+GMT&Content-Type=text%2Fhtml&CF-RAY=two"`
 
 func TestUnmarshalHeader(t *testing.T) {


### PR DESCRIPTION
Per title.

Having the json.Marshaler interface implemented is handy when mocking the Twilio server for testing.

Implementing the json.Marshaler interface for these types is sufficient for mocking Call and Message calls.