### PR TITLE
feat(chat): add push notification token inside the token

### DIFF
--- a/token/access_token_grant.go
+++ b/token/access_token_grant.go
@@ -160,14 +160,22 @@ func (gr *VideoGrant) Key() string {
 
 // ChatGrant is for Twilio Programmable Chat
 type ChatGrant struct {
-	serviceSid string
+	serviceSid        string
+	pushCredentialSid string
 }
 
-func NewChatGrant(sid string) *ChatGrant {
-	return &ChatGrant{serviceSid: sid}
+func NewChatGrant(sid, pushCredentialSid string) *ChatGrant {
+	return &ChatGrant{serviceSid: sid, pushCredentialSid: pushCredentialSid}
 }
 
 func (cg *ChatGrant) ToPayload() map[string]interface{} {
+	if len(cg.serviceSid) > 0 && len(cg.pushCredentialSid) > 0 {
+		return map[string]interface{}{
+			keyServiceSid:  cg.serviceSid,
+			keyPushCredSid: cg.pushCredentialSid,
+		}
+	}
+
 	if len(cg.serviceSid) > 0 {
 		return map[string]interface{}{
 			keyServiceSid: cg.serviceSid,

--- a/token/access_token_grant_test.go
+++ b/token/access_token_grant_test.go
@@ -109,7 +109,7 @@ func TestVideoGrant(t *testing.T) {
 
 func TestChatGrant(t *testing.T) {
 	t.Parallel()
-	chGrnt := NewChatGrant(SERVICE_SID)
+	chGrnt := NewChatGrant(SERVICE_SID, PUSH_CRED_SID)
 
 	if chGrnt.Key() != chatGrant {
 		t.Errorf("key expected to be %s, got %s\n", chatGrant, chGrnt.Key())
@@ -117,5 +117,9 @@ func TestChatGrant(t *testing.T) {
 
 	if chGrnt.ToPayload()[keyServiceSid] != SERVICE_SID {
 		t.Errorf("%s expected to be %s, got %s\n", keyServiceSid, SERVICE_SID, chGrnt.ToPayload()[keyServiceSid])
+	}
+
+	if chGrnt.ToPayload()[keyPushCredSid] != PUSH_CRED_SID {
+		t.Errorf("%s expected to be %s, got %s\n", keyPushCredSid, PUSH_CRED_SID, chGrnt.ToPayload()[keyPushCredSid])
 	}
 }


### PR DESCRIPTION
## Changelog

- Added: Possibility to add push notification key inside ChatGrant token.


See ref: https://www.twilio.com/docs/chat/javascript/push-notifications-web#step-4-pass-the-api-credential-sid-in-your-access-token