### PR TITLE
Add Serverless Services + Functions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The API is unlikely to change, and currently covers these resources:
 - Serverless
   - Service
   - Function
+  - Function Version
 
 ### Error Parsing
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The API is unlikely to change, and currently covers these resources:
 - Wireless
 - Voice Insights
 - Access Tokens for IPMessaging, Video and Programmable Voice SDK
+- Serverless
+  - Service
+  - Function
 
 ### Error Parsing
 

--- a/responses_test.go
+++ b/responses_test.go
@@ -66,6 +66,7 @@ func getServer(response []byte) (*Client, *Server) {
 	client.Video.Base = s.URL
 	client.TaskRouter.Base = s.URL
 	client.Insights.Base = s.URL
+	client.Serverless.Base = s.URL
 	return client, s
 }
 
@@ -81,6 +82,7 @@ func getServerCode(response []byte, code int) (*Client, *Server) {
 	client.Lookup.Base = s.URL
 	client.Video.Base = s.URL
 	client.TaskRouter.Base = s.URL
+	client.Serverless.Base = s.URL
 	return client, s
 }
 
@@ -2899,7 +2901,7 @@ var phoneLookupResponse = []byte(`
         "caller_name": "CCSF",
         "caller_type": "BUSINESS",
         "error_code": null
-    },    
+    },
     "carrier": {
         "type": "landline",
         "error_code": null,
@@ -2907,7 +2909,7 @@ var phoneLookupResponse = []byte(`
         "mobile_country_code": null,
         "name": "Pacific Bell"
     }
-}	
+}
 `)
 
 var verifyResponse = []byte(`

--- a/serverless.go
+++ b/serverless.go
@@ -1,0 +1,7 @@
+package twilio
+
+// ServerlessService allows for interaction with a Serverless Service
+type ServerlessService struct {
+	Functions *FunctionService
+	Function  func(sid string) *FunctionService
+}

--- a/serverless_function.go
+++ b/serverless_function.go
@@ -1,0 +1,104 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+)
+
+const functionPathPart = "Functions"
+
+type FunctionService struct {
+	client     *Client
+	serviceSid string
+
+	Versions *FunctionVersionService
+}
+
+type Function struct {
+	Sid          string     `json:"sid"`
+	AccountSid   string     `json:"account_sid"`
+	ServiceSid   string     `json:"service_sid"`
+	FriendlyName string     `json:"friendly_name"`
+	DateCreated  TwilioTime `json:"date_created"`
+	DateUpdated  TwilioTime `json:"date_updated"`
+	URL          string     `json:"url"`
+}
+
+type FunctionPage struct {
+	Page
+	Functions []*Function `json:"functions"`
+}
+
+// Get retrieves a Function by its sid.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/function for
+// more.
+func (f *FunctionService) Get(ctx context.Context, sid string) (*Function, error) {
+	function := new(Function)
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart)
+	err := f.client.GetResource(ctx, pathPart, sid, function)
+	return function, err
+}
+
+// Create creates a new Function.
+//
+// For a list of valid parameters see
+// https://www.twilio.com/docs/runtime/functions-assets-api/api/function.
+func (f *FunctionService) Create(ctx context.Context, data url.Values) (*Function, error) {
+	function := new(Function)
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart)
+	err := f.client.CreateResource(ctx, pathPart, data, function)
+	return function, err
+}
+
+// Delete deletes a Function.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/function for
+// more.
+func (f *FunctionService) Delete(ctx context.Context, sid string) error {
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart)
+	return f.client.DeleteResource(ctx, pathPart, sid)
+}
+
+// Update updates a Function, using the given data.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/function for
+// more.
+func (f *FunctionService) Update(ctx context.Context, sid string, data url.Values) (*Function, error) {
+	function := new(Function)
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart)
+	err := f.client.UpdateResource(ctx, pathPart, sid, data, function)
+	return function, err
+}
+
+// GetPage retrieves a FunctionPage, filtered by the given data.
+func (f *FunctionService) GetPage(ctx context.Context, data url.Values) (*FunctionPage, error) {
+	iter := f.GetPageIterator(data)
+	return iter.Next(ctx)
+}
+
+type FunctionPageIterator struct {
+	p *PageIterator
+}
+
+// GetPageIterator returns an iterator which can be used to retrieve pages.
+func (f *FunctionService) GetPageIterator(data url.Values) *FunctionPageIterator {
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart)
+	iter := NewPageIterator(f.client, data, pathPart)
+	return &FunctionPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (fpi *FunctionPageIterator) Next(ctx context.Context) (*FunctionPage, error) {
+	cp := new(FunctionPage)
+	err := fpi.p.Next(ctx, cp)
+	if err != nil {
+		return nil, err
+	}
+	fpi.p.SetNextPageURI(cp.NextPageURI)
+	return cp, nil
+}

--- a/serverless_function_test.go
+++ b/serverless_function_test.go
@@ -1,0 +1,96 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/kevinburke/twilio-go/testdata"
+)
+
+func TestGetFunction(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionResponse)
+	defer server.Close()
+
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	sid := "ZH691419f6825741bb96d2ea9af301d055"
+	name := "FunctionGet"
+
+	function, err := client.Serverless.Service(serviceSid).Functions.Get(context.Background(), sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if function.ServiceSid != serviceSid {
+		t.Errorf("function: got service sid %q, want %q", function.ServiceSid, serviceSid)
+	}
+
+	if function.FriendlyName != name {
+		t.Errorf("function: got friendly name %q, want %q", function.FriendlyName, name)
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions/" + sid
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}
+
+func TestCreateFunction(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionCreateResponse)
+	defer server.Close()
+
+	data := url.Values{}
+	newname := "Some Function"
+	data.Set("FriendlyName", newname)
+
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	function, err := client.Serverless.Service(serviceSid).Functions.Create(context.Background(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if function.ServiceSid != serviceSid {
+		t.Errorf("function: got service sid %q, want %q", function.ServiceSid, serviceSid)
+	}
+	if function.FriendlyName != newname {
+		t.Errorf("FriendlyNames don't match")
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions"
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}
+
+func TestPagedFunction(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionPageResponse)
+	defer server.Close()
+
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+
+	iterator := client.Serverless.Service(serviceSid).Functions.GetPageIterator(url.Values{"PageSize": []string{"50"}})
+	count := 0
+	for {
+		page, err := iterator.Next(context.Background())
+		if err == NoMoreResults {
+			break
+		}
+		count += len(page.Functions)
+	}
+
+	if count != 2 {
+		t.Errorf("Functions length is %d, want 2", count)
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions?PageSize=50"
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}

--- a/serverless_function_version.go
+++ b/serverless_function_version.go
@@ -1,0 +1,93 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+)
+
+const functionVersionPathPart = "Versions"
+
+type FunctionVersionService struct {
+	client      *Client
+	serviceSid  string
+	functionSid string
+}
+
+type FunctionVersion struct {
+	Sid         string     `json:"sid"`
+	AccountSid  string     `json:"account_sid"`
+	ServiceSid  string     `json:"service_sid"`
+	FunctionSid string     `json:"function_sid"`
+	Path        string     `json:"path"`
+	Visibility  string     `json:"visibility"`
+	DateCreated TwilioTime `json:"date_created"`
+	URL         string     `json:"url"`
+}
+
+type FunctionVersionContent struct {
+	Sid         string `json:"sid"`
+	AccountSid  string `json:"account_sid"`
+	ServiceSid  string `json:"service_sid"`
+	FunctionSid string `json:"function_sid"`
+	Content     string `json:"content"`
+	URL         string `json:"url"`
+}
+
+type FunctionVersionPage struct {
+	Page
+	FunctionVersions []*FunctionVersion `json:"function_versions"`
+}
+
+// Get retrieves a Function Version by its sid.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/function for
+// more.
+func (f *FunctionVersionService) Get(ctx context.Context, sid string) (*FunctionVersion, error) {
+	fv := new(FunctionVersion)
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart, f.functionSid, functionVersionPathPart)
+	err := f.client.GetResource(ctx, pathPart, sid, fv)
+	return fv, err
+}
+
+// Get retrieves a Function Version Content by its sid.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/function-version/function-version-content
+// for more.
+func (f *FunctionVersionService) GetContent(ctx context.Context, sid string) (*FunctionVersionContent, error) {
+	fvc := new(FunctionVersionContent)
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart, f.functionSid, functionVersionPathPart)
+	err := f.client.GetResource(ctx, pathPart, sid+"/Content", fvc)
+	return fvc, err
+}
+
+// GetPage retrieves a FunctionVersionPage, filtered by the given data.
+func (f *FunctionVersionService) GetPage(ctx context.Context, data url.Values) (*FunctionVersionPage, error) {
+	iter := f.GetPageIterator(data)
+	return iter.Next(ctx)
+}
+
+type FunctionVersionPageIterator struct {
+	p *PageIterator
+}
+
+// GetPageIterator returns an iterator which can be used to retrieve pages.
+func (f *FunctionVersionService) GetPageIterator(data url.Values) *FunctionVersionPageIterator {
+	pathPart := filepath.Join(servicesPathPrefix, f.serviceSid, functionPathPart, f.functionSid, functionVersionPathPart)
+	iter := NewPageIterator(f.client, data, pathPart)
+	return &FunctionVersionPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (fpi *FunctionVersionPageIterator) Next(ctx context.Context) (*FunctionVersionPage, error) {
+	cp := new(FunctionVersionPage)
+	err := fpi.p.Next(ctx, cp)
+	if err != nil {
+		return nil, err
+	}
+	fpi.p.SetNextPageURI(cp.NextPageURI)
+	return cp, nil
+}

--- a/serverless_function_version_test.go
+++ b/serverless_function_version_test.go
@@ -1,0 +1,123 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/kevinburke/twilio-go/testdata"
+)
+
+func TestGetFunctionVersion(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionResponse)
+	defer server.Close()
+
+	ctx := context.Background()
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	functionSid := "ZH691419f6825741bb96d2ea9af301d055"
+	sid := "ZN684765f345f046b5aff4f6d29eea30d4"
+
+	function, err := client.Serverless.Service(serviceSid).Functions.Get(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versionClient, versionServer := getServer(testdata.ServerlessFunctionVersionResponse)
+	defer versionServer.Close()
+
+	version, err := versionClient.Serverless.Service(serviceSid).Function(function.Sid).Versions.Get(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pathName := "/test-path"
+	if version.Path != pathName {
+		t.Errorf("function version: got path %q, want %q", version.Path, pathName)
+	}
+
+	if len(versionServer.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(versionServer.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions/" + functionSid + "/Versions/" + sid
+	if versionServer.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", versionServer.URLs[0], want)
+	}
+}
+
+func TestPagedFunctionVersion(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionResponse)
+	defer server.Close()
+
+	ctx := context.Background()
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	functionSid := "ZH691419f6825741bb96d2ea9af301d055"
+	sid := "ZN684765f345f046b5aff4f6d29eea30d4"
+
+	function, err := client.Serverless.Service(serviceSid).Functions.Get(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versionClient, versionServer := getServer(testdata.ServerlessFunctionVersionsResponse)
+	defer versionServer.Close()
+
+	iterator := versionClient.Serverless.Service(serviceSid).Function(function.Sid).Versions.GetPageIterator(url.Values{"PageSize": []string{"50"}})
+	count := 0
+	for {
+		page, err := iterator.Next(context.Background())
+		if err == NoMoreResults {
+			break
+		}
+		count += len(page.FunctionVersions)
+	}
+
+	if count != 2 {
+		t.Errorf("FunctionVersions length is %d, want 2", count)
+	}
+	if len(versionServer.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(versionServer.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions/" + functionSid + "/Versions?PageSize=50"
+	if versionServer.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", versionServer.URLs[0], want)
+	}
+}
+
+func TestGetFunctionVersionContent(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessFunctionResponse)
+	defer server.Close()
+
+	ctx := context.Background()
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	functionSid := "ZH691419f6825741bb96d2ea9af301d055"
+	sid := "ZN684765f345f046b5aff4f6d29eea30d4"
+
+	function, err := client.Serverless.Service(serviceSid).Functions.Get(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versionClient, versionServer := getServer(testdata.ServerlessFunctionVersionContentResponse)
+	defer versionServer.Close()
+
+	versionContent, err := versionClient.Serverless.Service(serviceSid).Function(function.Sid).Versions.GetContent(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedContent := "exports.handler = function (context, event, callback) { console.log(event) };"
+	if versionContent.Content != expectedContent {
+		t.Errorf("function version content: got content %q, want %q", versionContent.Content, expectedContent)
+	}
+
+	if len(versionServer.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(versionServer.URLs))
+	}
+	want := "/v1/Services/" + serviceSid + "/Functions/" + functionSid + "/Versions/" + sid + "/Content"
+	if versionServer.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", versionServer.URLs[0], want)
+	}
+}

--- a/serverless_service.go
+++ b/serverless_service.go
@@ -1,0 +1,97 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+)
+
+const servicesPathPrefix = "Services"
+
+type ServiceService struct {
+	client *Client
+}
+
+type Service struct {
+	Sid                string     `json:"sid"`
+	AccountSid         string     `json:"account_sid"`
+	FriendlyName       string     `json:"friendly_name"`
+	UniqueName         string     `json:"unique_name"`
+	IncludeCredentials bool       `json:"include_credentials"`
+	UIEditable         bool       `json:"ui_editable"`
+	DateCreated        TwilioTime `json:"date_created"`
+	DateUpdated        TwilioTime `json:"date_updated"`
+	URL                string     `json:"url"`
+}
+
+type ServicePage struct {
+	Page
+	Services []*Service `json:"services"`
+}
+
+// Get retrieves a Service by its sid.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/Service for
+// more.
+func (s *ServiceService) Get(ctx context.Context, sid string) (*Service, error) {
+	service := new(Service)
+	err := s.client.GetResource(ctx, servicesPathPrefix, sid, service)
+	return service, err
+}
+
+// Create creates a new Service.
+//
+// For a list of valid parameters see
+// https://www.twilio.com/docs/runtime/functions-assets-api/api/Service.
+func (s *ServiceService) Create(ctx context.Context, data url.Values) (*Service, error) {
+	service := new(Service)
+	err := s.client.CreateResource(ctx, servicesPathPrefix, data, service)
+	return service, err
+}
+
+// Delete deletes an Service.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/Service for
+// more.
+func (s *ServiceService) Delete(ctx context.Context, sid string) error {
+	return s.client.DeleteResource(ctx, servicesPathPrefix, sid)
+}
+
+// Update updates an Service, using the given data.
+//
+// See https://www.twilio.com/docs/runtime/functions-assets-api/api/Service for
+// more.
+func (s *ServiceService) Update(ctx context.Context, sid string, data url.Values) (*Service, error) {
+	service := new(Service)
+	err := s.client.UpdateResource(ctx, servicesPathPrefix, sid, data, service)
+	return service, err
+}
+
+// GetPage retrieves an ServicePage, filtered by the given data.
+func (s *ServiceService) GetPage(ctx context.Context, data url.Values) (*ServicePage, error) {
+	iter := s.GetPageIterator(data)
+	return iter.Next(ctx)
+}
+
+type ServicePageIterator struct {
+	p *PageIterator
+}
+
+// GetPageIterator returns an iterator which can be used to retrieve pages.
+func (s *ServiceService) GetPageIterator(data url.Values) *ServicePageIterator {
+	iter := NewPageIterator(s.client, data, servicesPathPrefix)
+	return &ServicePageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (spi *ServicePageIterator) Next(ctx context.Context) (*ServicePage, error) {
+	sp := new(ServicePage)
+	err := spi.p.Next(ctx, sp)
+	if err != nil {
+		return nil, err
+	}
+	spi.p.SetNextPageURI(sp.NextPageURI)
+	return sp, nil
+}

--- a/serverless_service_test.go
+++ b/serverless_service_test.go
@@ -1,0 +1,89 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/kevinburke/twilio-go/testdata"
+)
+
+func TestGetService(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessServiceResponse)
+	defer server.Close()
+
+	serviceSid := "ZSc6c0e43c485bfd439d6e076abb51aaa6"
+	name := "ServiceGet"
+
+	srv, err := client.Serverless.Services.Get(context.Background(), serviceSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if srv.Sid != serviceSid {
+		t.Errorf("service: got sid %q, want %q", srv.Sid, serviceSid)
+	}
+
+	if srv.FriendlyName != name {
+		t.Errorf("service: got friendly name  %q, want %q", srv.FriendlyName, name)
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services/" + serviceSid
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}
+
+func TestCreateService(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessServiceCreateResponse)
+	defer server.Close()
+
+	data := url.Values{}
+	newname := "Some Service"
+	data.Set("FriendlyName", newname)
+
+	srv, err := client.Serverless.Services.Create(context.Background(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if srv.FriendlyName != newname {
+		t.Errorf("FriendlyNames don't match")
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services"
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}
+
+func TestPagedService(t *testing.T) {
+	t.Parallel()
+	client, server := getServer(testdata.ServerlessServicePageResponse)
+	defer server.Close()
+
+	iterator := client.Serverless.Services.GetPageIterator(url.Values{"PageSize": []string{"50"}})
+	count := 0
+	for {
+		page, err := iterator.Next(context.Background())
+		if err == NoMoreResults {
+			break
+		}
+		count += len(page.Services)
+	}
+
+	if count != 2 {
+		t.Errorf("Services length is %d, want 2", count)
+	}
+	if len(server.URLs) != 1 {
+		t.Errorf("URL length is %d, want 1", len(server.URLs))
+	}
+	want := "/v1/Services?PageSize=50"
+	if server.URLs[0].String() != want {
+		t.Errorf("request URL:\ngot  %q\nwant %q", server.URLs[0], want)
+	}
+}

--- a/testdata/serverless_responses.go
+++ b/testdata/serverless_responses.go
@@ -74,13 +74,13 @@ var ServerlessFunctionPageResponse = []byte(`
 {
   "functions": [` + string(ServerlessFunctionResponse) + `,` + string(ServerlessFunctionResponse) + `],
   "meta": {
-    "first_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0",
+    "first_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions?PageSize=50&Page=0",
     "key": "functions",
-    "next_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=1",
+    "next_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions?PageSize=50&Page=1",
     "page": 0,
     "page_size": 50,
-    "previous_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0",
-    "url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0"
+    "previous_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions?PageSize=50&Page=0",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions?PageSize=50&Page=0"
   }
 }
 `)

--- a/testdata/serverless_responses.go
+++ b/testdata/serverless_responses.go
@@ -1,0 +1,143 @@
+package testdata
+
+var ServerlessServiceResponse = []byte(`
+{
+    "sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "friendly_name": "ServiceGet",
+    "unique_name": "twilio-go-service-client-testing-app",
+    "include_credentials": true,
+    "ui_editable": false,
+    "date_created": "2020-11-18T16:52:30Z",
+    "date_updated": "2020-11-18T16:52:30Z",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "links": {
+      "environments": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Environments",
+      "functions": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions",
+      "assets": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Assets",
+      "builds": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Builds"
+    }
+}
+`)
+
+var ServerlessServiceCreateResponse = []byte(`
+{
+    "sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "friendly_name": "Some Service",
+    "unique_name": "twilio-go-service-client-testing-app",
+    "include_credentials": true,
+    "ui_editable": false,
+    "date_created": "2020-11-18T16:52:30Z",
+    "date_updated": "2020-11-18T16:52:30Z",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "links": {
+      "environments": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Environments",
+      "functions": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions",
+      "assets": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Assets",
+      "builds": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Builds"
+    }
+}
+`)
+
+var ServerlessServicePageResponse = []byte(`
+{
+  "services": [` + string(ServerlessServiceResponse) + `,` + string(ServerlessServiceResponse) + `],
+  "meta": {
+    "first_page_url": "https://serverless.twilio.com/v1/Services?PageSize=50&Page=0",
+    "key": "services",
+    "next_page_url": "https://serverless.twilio.com/v1/Services?PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://serverless.twilio.com/v1/Services?PageSize=50&Page=0",
+    "url": "https://serverless.twilio.com/v1/Services?PageSize=50&Page=0"
+  }
+}
+`)
+
+var ServerlessFunctionResponse = []byte(`
+{
+    "sid": "ZH691419f6825741bb96d2ea9af301d055",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "service_sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "friendly_name": "FunctionGet",
+    "date_created": "2020-11-10T20:00:00Z",
+    "date_updated": "2020-11-10T20:00:00Z",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055",
+    "links": {
+      "function_versions": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions"
+    }
+}
+`)
+
+var ServerlessFunctionPageResponse = []byte(`
+{
+  "functions": [` + string(ServerlessFunctionResponse) + `,` + string(ServerlessFunctionResponse) + `],
+  "meta": {
+    "first_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0",
+    "key": "functions",
+    "next_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0",
+    "url": "https://serverless.twilio.com/v1/Services/ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Functions?PageSize=50&Page=0"
+  }
+}
+`)
+
+var ServerlessFunctionCreateResponse = []byte(`
+{
+    "sid": "ZH20ac9c3583cb49eb80f833857ad8f696",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "service_sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "friendly_name": "Some Function",
+    "date_created": "2020-11-10T20:00:00Z",
+    "date_updated": "2020-11-10T20:00:00Z",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH20ac9c3583cb49eb80f833857ad8f696",
+    "links": {
+      "function_versions": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH20ac9c3583cb49eb80f833857ad8f696/Versions"
+    }
+}
+`)
+
+var ServerlessFunctionVersionResponse = []byte(`
+{
+    "sid": "ZN684765f345f046b5aff4f6d29eea30d4",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "service_sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "function_sid": "ZH691419f6825741bb96d2ea9af301d055",
+    "path": "/test-path",
+    "visibility": "public",
+    "date_created": "2020-11-10T20:00:00Z",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions/ZN684765f345f046b5aff4f6d29eea30d4",
+    "links": {
+      "function_version_content": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions/ZN684765f345f046b5aff4f6d29eea30d4/Content"
+    }
+}
+`)
+
+var ServerlessFunctionVersionsResponse = []byte(`
+{
+    "function_versions": [` + string(ServerlessFunctionVersionResponse) + `,` + string(ServerlessFunctionVersionResponse) + `],
+    "meta": {
+      "first_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions?PageSize=50&Page=0",
+      "key": "function_versions",
+      "next_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions?PageSize=50&Page=1",
+      "page": 0,
+      "page_size": 50,
+      "previous_page_url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions?PageSize=50&Page=0",
+      "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions?PageSize=50&Page=0"
+    }
+}
+`)
+
+var ServerlessFunctionVersionContentResponse = []byte(`
+{
+    "sid": "ZN684765f345f046b5aff4f6d29eea30d4",
+    "account_sid": "AC58f1e8f2b1c6b88ca90a012a4be0c279",
+    "service_sid": "ZSc6c0e43c485bfd439d6e076abb51aaa6",
+    "function_sid": "ZH691419f6825741bb96d2ea9af301d055",
+    "content": "exports.handler = function (context, event, callback) { console.log(event) };",
+    "url": "https://serverless.twilio.com/v1/Services/ZSc6c0e43c485bfd439d6e076abb51aaa6/Functions/ZH691419f6825741bb96d2ea9af301d055/Versions/ZN684765f345f046b5aff4f6d29eea30d4/Content"
+}
+`)


### PR DESCRIPTION
**Description**

Adds a few APIs from the [Functions & Assets (API)](https://www.twilio.com/docs/runtime/functions-assets-api):

- Service
- Function
- Function Version

**Notes**

- I followed the naming convention of the repo, but that resulted in a stuttering struct name `ServiceService`. Open to suggestions if that is an issue.

**Usage**
A combined example showing a chained use case:
```go
client := twilio.NewClient(sid, token, nil)
maxPageSize := url.Values{"PageSize": []string{"50"}}
iterator := client.Serverless.Services.GetPageIterator(maxPageSize)
for {
	page, err := iterator.Next(ctx)
	if err == twilio.NoMoreResults {
		break
	}
	for _, s := range page.Services {
		fmt.Printf("service: %#v\n", s)
		service := client.Serverless.Service(s.Sid)
		funcIter := service.Functions.GetPageIterator(maxPageSize)
		for {
			fPage, err := funcIter.Next(ctx)
			if err == twilio.NoMoreResults {
				break
			}
			for _, f := range fPage.Functions {
				fmt.Printf("function: %#v\n", f)
				versions := service.Function(f.Sid).Versions
				verIter := versions.GetPageIterator(maxPageSize)
				for {
					fvPage, err := verIter.Next(ctx)
					if err == twilio.NoMoreResults {
						break
					}

					latestVersion := fvPage.FunctionVersions[0]
					fmt.Printf("latest version: %#v\n", latestVersion)

					content, err := versions.GetContent(ctx, latestVersion.Sid)
					if err != nil {
						return err
					}
					fmt.Printf("content: %#v\n", content)
				}
			}
		}
	}
}
```