### PR TITLE
Update IntervalMetrics structure from Twilio Voice Insights API

### DIFF
--- a/responses_test.go
+++ b/responses_test.go
@@ -3174,31 +3174,6 @@ var insightsCallMetricsResponse = []byte(`
 {
    "metrics": [
         {
-            "direction": "inbound",
-            "sip_edge": null,
-            "timestamp": "2020-01-06T15:21:47.017Z",
-            "client_edge": null,
-            "account_sid": "ACabe5149d2ba84a81a7515e425abda4fd",
-            "sdk_edge": null,
-            "edge": "carrier_edge",
-            "call_sid": "CA04917eab5c194f4c86207384933c0c41",
-            "carrier_edge": {
-                "cumulative": {
-                    "jitter": {
-                        "max": 0.010499,
-                        "avg": 0.00553242
-                    },
-                    "packets_received": 478,
-                    "packets_lost": 0
-                },
-                "codec": 0,
-                "codec_name": "pcmu",
-                "metadata": {
-                    "region": "us1"
-                }
-            }
-        },
-        {
             "direction": "outbound",
             "sip_edge": null,
             "timestamp": "2020-01-06T15:21:48.006Z",
@@ -3223,6 +3198,44 @@ var insightsCallMetricsResponse = []byte(`
                 }
             }
         },
+		{
+		  "timestamp": "2019-10-07T22:32:06Z",
+		  "call_sid": "CA04917eab5c194f4c86207384933c0c41",
+		  "account_sid": "ACabe5149d2ba84a81a7515e425abda4fd",
+		  "edge": "sdk_edge",
+		  "direction": "both",
+		  "sdk_edge": {
+			"interval": {
+			  "packets_received": 50,
+			  "packets_lost": 0,
+			  "audio_in": {
+				"value": 81.0
+			  },
+			  "audio_out": {
+				"value": 5237.0
+			  },
+			  "jitter": {
+				"value": 9
+			  },
+			  "mos": {
+				"value": 4.39
+			  },
+			  "rtt": {
+				"value": 81
+			  }
+			},
+			"cumulative": {
+			  "bytes_received": 547788,
+			  "bytes_sent": 329425,
+			  "packets_received": 3900,
+			  "packets_lost": 0,
+			  "packets_sent": 3934
+			}
+		  },
+		  "client_edge": null,
+		  "carrier_edge": null,
+		  "sip_edge": null
+		},
         {
             "direction": "inbound",
             "sip_edge": null,

--- a/voice_insights_metrics.go
+++ b/voice_insights_metrics.go
@@ -49,13 +49,19 @@ type CumulativeMetrics struct {
 	PacketsLost     int            `json:"packets_lost"`
 }
 
+type FloatValue struct {
+	Value float64 `json:"value"`
+}
+
 type IntervalMetrics struct {
-	AudioOut              int     `json:"audio_out"`
-	AudioIn               int     `json:"audio_in"`
-	Jitter                int     `json:"jitter"`
-	RTT                   int     `json:"rtt"`
-	PacketsLost           int     `json:"packets_lost"`
-	PacketsLossPercentage float64 `json:"packets_loss_percentage"`
+	AudioOut              FloatValue `json:"audio_out"`
+	AudioIn               FloatValue `json:"audio_in"`
+	Jitter                FloatValue `json:"jitter"`
+	MOS                   FloatValue `json:"mos"`
+	RTT                   FloatValue `json:"rtt"`
+	PacketsReceived       int        `json:"packets_received"`
+	PacketsLost           int        `json:"packets_lost"`
+	PacketsLossPercentage float64    `json:"packets_loss_percentage"`
 }
 
 // Returns a list of metrics for a call. For more information on valid values,

--- a/voice_insights_metrics_test.go
+++ b/voice_insights_metrics_test.go
@@ -25,10 +25,18 @@ func TestGetCallMetrics(t *testing.T) {
 	if page.Metrics[0].CallSid != sid {
 		t.Errorf("expected CallSid to be %s, got %s", sid, page.Metrics[0].CallSid)
 	}
+
 	if page.Metrics[0].Edge != "carrier_edge" {
 		t.Errorf("expected Edge to be 'carrier_edge', got %s", page.Metrics[0].Edge)
 	}
 	if page.Metrics[0].CarrierEdge == nil {
 		t.Error("expected Carrier Edge metrics to be available")
+	}
+
+	if page.Metrics[1].Edge != "sdk_edge" {
+		t.Errorf("expected Edge to be 'sdk_edge', got %s", page.Metrics[1].Edge)
+	}
+	if page.Metrics[1].SDKEdge == nil {
+		t.Error("expected SDK Edge metrics to be available")
 	}
 }


### PR DESCRIPTION
Twilio has updated the `IntervalMetrics` structure to using an object instead of a flat float value for the Voice Insights metrics API.

**Previous**
```
"audio_in":  81.0
```

**Now**
```
"audio_in": {
    "value": 81.0
}
```

Reference here: https://www.twilio.com/docs/voice/insights/api/call-metrics-resource#get-call-metrics